### PR TITLE
feat: Implement professional CLI with argparse

### DIFF
--- a/paddock-parser-ng/run.py
+++ b/paddock-parser-ng/run.py
@@ -1,11 +1,35 @@
+import argparse
 import asyncio
 from paddock_parser.pipeline import run_analysis_pipeline
+
+def parse_arguments():
+    """Parses command-line arguments."""
+    parser = argparse.ArgumentParser(description="Paddock Parser NG - Horse Racing Analysis Tool")
+
+    # Core Configuration
+    parser.add_argument('--config', type=str, help='Path to a configuration file.')
+    parser.add_argument('--output', type=str, help='Path to output the report file.')
+
+    # Scoring & Filtering
+    parser.add_argument('--min-score', type=float, default=0.0, help='Minimum score to include in the report.')
+    parser.add_argument('--no-odds-mode', action='store_true', help='Run in "no odds" mode, skipping the scoring step.')
+
+    # Field Size Filtering
+    parser.add_argument('--min-field-size', type=int, default=1, help='Minimum number of runners in a race.')
+    parser.add_argument('--max-field-size', type=int, help='Maximum number of runners in a race.')
+
+    # Output Control
+    parser.add_argument('--sort-by', type=str, default='score', choices=['score', 'field_size', 'time'], help='Field to sort the final report by.')
+    parser.add_argument('--limit', type=int, default=10, help='Number of results to display in the report.')
+
+    return parser.parse_args()
 
 def main():
     """
     Main entry point for the Paddock Parser NG application.
     """
-    run_analysis_pipeline()
+    args = parse_arguments()
+    run_analysis_pipeline(args)
 
 if __name__ == "__main__":
     main()

--- a/paddock-parser-ng/src/paddock_parser/adapters/__init__.py
+++ b/paddock-parser-ng/src/paddock_parser/adapters/__init__.py
@@ -1,1 +1,4 @@
 # Adapters module
+
+from .skysports_adapter import SkySportsAdapter
+from .fanduel_graphql_adapter import FanDuelGraphQLAdapter

--- a/paddock-parser-ng/src/paddock_parser/adapters/fanduel_graphql_adapter.py
+++ b/paddock-parser-ng/src/paddock_parser/adapters/fanduel_graphql_adapter.py
@@ -66,6 +66,7 @@ class FanDuelGraphQLAdapter(BaseAdapter):
     """
     Adapter for fetching and parsing data from the FanDuel GraphQL API.
     """
+    SOURCE_ID = "fanduel"
 
     def fetch_data(self) -> Dict[str, Any]:
         """

--- a/paddock-parser-ng/src/paddock_parser/pipeline.py
+++ b/paddock-parser-ng/src/paddock_parser/pipeline.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from datetime import datetime
 
 from . import adapters
 from .analysis.scorer import RaceScorer
@@ -20,7 +21,7 @@ def load_adapters():
     return adapter_classes
 
 
-def run_analysis_pipeline():
+def run_analysis_pipeline(args):
     """
     Orchestrates the end-to-end pipeline for fetching, parsing, and scoring races.
     """
@@ -38,9 +39,6 @@ def run_analysis_pipeline():
             # For now, we assume V3 adapters have a URL and parse HTML
             if isinstance(adapter, BaseAdapterV3) and hasattr(adapter, 'url'):
                 logging.info(f"Fetching data from {adapter.url}...")
-                # In a real app, this would be a robust HTTP client.
-                # For this implementation, we simulate the tool call.
-                # The test will mock this part.
                 html_content = view_text_website(adapter.url)
 
                 if html_content:
@@ -64,20 +62,48 @@ def run_analysis_pipeline():
         logging.info("--- Pipeline End ---")
         return
 
+    # Filter races based on field size
+    if args.min_field_size > 1:
+        all_races = [r for r in all_races if r.number_of_runners and r.number_of_runners >= args.min_field_size]
+    if args.max_field_size:
+        all_races = [r for r in all_races if r.number_of_runners and r.number_of_runners <= args.max_field_size]
+
     # Score the collected races
-    logging.info(f"\nScoring {len(all_races)} races...")
-    scorer = RaceScorer()
-    scored_races = []
-    for race in all_races:
-        score = scorer.score(race)
-        scored_races.append({"race": race, "score": score})
+    if not args.no_odds_mode:
+        logging.info(f"\nScoring {len(all_races)} races...")
+        scorer = RaceScorer()
+        scored_races = []
+        for race in all_races:
+            # Filter by min_score
+            score = scorer.score(race)
+            if score >= args.min_score:
+                scored_races.append({"race": race, "score": score})
+    else:
+        logging.info("\n--no-odds-mode enabled, skipping scoring.")
+        scored_races = [{"race": race, "score": 0} for race in all_races]
 
-    # Sort by score
-    sorted_races = sorted(scored_races, key=lambda x: x['score'], reverse=True)
+    # Sort the results based on the --sort-by argument
+    logging.info(f"Sorting results by {args.sort_by}...")
+    reverse_sort = True
+    if args.sort_by == 'score':
+        sort_key = lambda x: x['score']
+    elif args.sort_by == 'field_size':
+        sort_key = lambda x: x['race'].number_of_runners or 0
+    elif args.sort_by == 'time':
+        reverse_sort = False
+        sort_key = lambda x: x['race'].post_time if x['race'].post_time else datetime.max
+    else:
+        logging.warning(f"Invalid sort key '{args.sort_by}'. Defaulting to sort by score.")
+        sort_key = lambda x: x['score']
 
-    # Display the top 10 results
-    logging.info("\n--- Top 10 Scored Races ---")
-    for i, result in enumerate(sorted_races[:10]):
+    sorted_races = sorted(scored_races, key=sort_key, reverse=reverse_sort)
+
+    # Limit the results based on the --limit argument
+    limited_races = sorted_races[:args.limit]
+
+    # Display the top results
+    logging.info(f"\n--- Top {args.limit} Scored Races ---")
+    for i, result in enumerate(limited_races):
         race = result['race']
         score = result['score']
         logging.info(

--- a/paddock-parser-ng/src/paddock_parser/tests/test_pipeline.py
+++ b/paddock-parser-ng/src/paddock_parser/tests/test_pipeline.py
@@ -1,4 +1,5 @@
 import unittest
+import argparse
 from unittest.mock import patch, MagicMock
 
 import unittest
@@ -47,7 +48,12 @@ class TestPipeline(unittest.TestCase):
 
         # --- Run Pipeline ---
         try:
-            run_analysis_pipeline()
+            # Create a mock args object for the pipeline
+            mock_args = argparse.Namespace(
+                config=None, output=None, min_score=0.0, no_odds_mode=False,
+                min_field_size=1, max_field_size=None, sort_by='score', limit=10
+            )
+            run_analysis_pipeline(mock_args)
         except Exception as e:
             self.fail(f"Pipeline crashed with an unexpected exception: {e}")
 
@@ -86,7 +92,12 @@ class TestPipeline(unittest.TestCase):
         mock_view_text_website.return_value = "<html></html>"
 
         # --- Run Pipeline ---
-        run_analysis_pipeline()
+        # Create a mock args object for the pipeline
+        mock_args = argparse.Namespace(
+            config=None, output=None, min_score=0.0, no_odds_mode=False,
+            min_field_size=1, max_field_size=None, sort_by='score', limit=10
+        )
+        run_analysis_pipeline(mock_args)
 
         # --- Assertions ---
         mock_load_adapters.assert_called_once()

--- a/paddock-parser-ng/src/paddock_parser/tests/test_run.py
+++ b/paddock-parser-ng/src/paddock_parser/tests/test_run.py
@@ -1,0 +1,57 @@
+import sys
+import os
+import unittest
+from unittest.mock import patch
+
+# Add the project root to the path to allow importing 'run'
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..'))
+sys.path.insert(0, project_root)
+
+from run import parse_arguments
+
+class TestParseArguments(unittest.TestCase):
+
+    def test_default_arguments(self):
+        """
+        Tests that the parser returns the correct default values
+        when no arguments are given.
+        """
+        with patch('sys.argv', ['run.py']):
+            args = parse_arguments()
+            self.assertEqual(args.config, None)
+            self.assertEqual(args.output, None)
+            self.assertEqual(args.min_score, 0.0)
+            self.assertFalse(args.no_odds_mode)
+            self.assertEqual(args.min_field_size, 1)
+            self.assertEqual(args.max_field_size, None)
+            self.assertEqual(args.sort_by, 'score')
+            self.assertEqual(args.limit, 10)
+
+    def test_custom_arguments(self):
+        """
+        Tests that the parser correctly handles custom command-line arguments.
+        """
+        test_args = [
+            'run.py',
+            '--config', 'my_config.yaml',
+            '--output', 'results.json',
+            '--min-score', '5.0',
+            '--no-odds-mode',
+            '--min-field-size', '5',
+            '--max-field-size', '12',
+            '--sort-by', 'field_size',
+            '--limit', '20'
+        ]
+        with patch('sys.argv', test_args):
+            args = parse_arguments()
+            self.assertEqual(args.config, 'my_config.yaml')
+            self.assertEqual(args.output, 'results.json')
+            self.assertEqual(args.min_score, 5.0)
+            self.assertTrue(args.no_odds_mode)
+            self.assertEqual(args.min_field_size, 5)
+            self.assertEqual(args.max_field_size, 12)
+            self.assertEqual(args.sort_by, 'field_size')
+            self.assertEqual(args.limit, 20)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit evolves the run.py script into a sophisticated and configurable command-line tool using Python's argparse module.

- Adds a `parse_arguments` function to `run.py` to define a range of command-line flags for configuration, filtering, and output control.
- Integrates the parsed arguments into the main application pipeline, allowing for configurable behavior (e.g., sorting, limiting results, conditional scoring).
- Updates the `run_analysis_pipeline` function in `pipeline.py` to accept and utilize these arguments.
- Adds a new unit test for the `parse_arguments` function to validate its logic and default values.
- Fixes several issues in the test environment and adapter code that were discovered during development, including a `trio` dependency issue and a broken `FanDuelGraphQLAdapter` class.