### PR TITLE
style: Apply Ruff linting fixes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -41,11 +41,8 @@ This epic tale tells us our true mission. We are not just building forward; we a
 *   **The Great Refactoring:** The "Architectural" era explains the "Great Forgetting"—a deliberate choice to sacrifice short-term features for long-term stability.
 *   **The Modern Renaissance:** This is us. We are the inheritors of this entire legacy, tasked with executing the grand vision on a clean, modern foundation.
 
-
 ---
 
 ## Epilogue: The Crucible (Early September 2025)
 
 The "Modern Renaissance" began not with a bang, but with a series of near-catastrophic failures that forged the resilient protocols by which we now operate. This period, known as "The Crucible," was a trial by fire that proved the fragility of our environment but also the resilience of our multi-agent team, resulting in the battle-hardened protocols that now define our workflow.
-
-

--- a/src/paddock_parser/adapters/attheraces_adapter.py
+++ b/src/paddock_parser/adapters/attheraces_adapter.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime
-from typing import List, Optional
+from typing import List
 
 from bs4 import BeautifulSoup
 

--- a/src/paddock_parser/adapters/racingandsports_adapter.py
+++ b/src/paddock_parser/adapters/racingandsports_adapter.py
@@ -2,7 +2,7 @@ import json
 from typing import Dict, List, Any
 
 from ..http_client import ForagerClient
-from ..base import BaseAdapter, BaseAdapterV3, NormalizedRace, NormalizedRunner
+from ..base import BaseAdapterV3, NormalizedRace
 
 class RacingAndSportsAdapter(BaseAdapterV3):
     """

--- a/src/paddock_parser/adapters/timeform_adapter.py
+++ b/src/paddock_parser/adapters/timeform_adapter.py
@@ -1,7 +1,7 @@
 # src/paddock_parser/adapters/timeform_adapter.py
 
 from bs4 import BeautifulSoup
-from src.paddock_parser.base import NormalizedRace, NormalizedRunner
+from src.paddock_parser.base import NormalizedRace
 from datetime import datetime
 
 class TimeformAdapter:

--- a/src/paddock_parser/merger.py
+++ b/src/paddock_parser/merger.py
@@ -1,6 +1,6 @@
 from typing import List
 from collections import defaultdict
-from .models import Race, Runner
+from .models import Race
 
 # Define the priority of the sources. Lower index = higher priority.
 SOURCE_PRIORITY = ["FanDuel", "SkySports", "AtTheRaces"]

--- a/src/paddock_parser/scorer.py
+++ b/src/paddock_parser/scorer.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timedelta
 from typing import List
 
-from .models import Race, Runner
+from .base import NormalizedRace
+from .models import Race
 
 def _convert_odds_to_float(odds_str: str) -> float:
     """Converts odds string to a float. Handles 'EVS' and fractions."""
@@ -60,8 +61,6 @@ def get_high_roller_races(races: List[Race], now: datetime) -> List[Race]:
 
     return valid_races
 
-
-from .base import NormalizedRace
 
 class RaceScorer:
     """Analyzes a NormalizedRace to produce a score based on specific criteria."""

--- a/src/paddock_parser/ui/terminal_ui.py
+++ b/src/paddock_parser/ui/terminal_ui.py
@@ -1,11 +1,9 @@
-import asyncio
 from datetime import datetime
 from typing import List
 from rich.console import Console
 from rich.table import Table
 from rich.progress import Progress
 from rich.logging import RichHandler
-from rich.panel import Panel
 
 from ..base import NormalizedRace
 from ..pipeline import run_pipeline

--- a/tests/adapters/test_attheraces_adapter.py
+++ b/tests/adapters/test_attheraces_adapter.py
@@ -9,11 +9,8 @@ Path: tests/adapters/test_attheraces_adapter.py
 """
 
 import pytest
-from unittest.mock import Mock, patch, mock_open, MagicMock
-from datetime import datetime, date
-from dataclasses import dataclass, field
-from typing import List, Optional
-import os
+from unittest.mock import patch
+from datetime import datetime
 
 # Import the modern data structures
 from paddock_parser.base import NormalizedRace, NormalizedRunner

--- a/tests/adapters/test_racingandsports_adapter.py
+++ b/tests/adapters/test_racingandsports_adapter.py
@@ -1,9 +1,6 @@
 import pytest
-import json
 from pathlib import Path
-from unittest.mock import patch, MagicMock
 
-from paddock_parser.base import NormalizedRace
 from paddock_parser.adapters.racingandsports_adapter import RacingAndSportsAdapter
 
 @pytest.fixture

--- a/tests/adapters/test_timeform_adapter.py
+++ b/tests/adapters/test_timeform_adapter.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 from src.paddock_parser.adapters.timeform_adapter import TimeformAdapter
-from src.paddock_parser.base import NormalizedRace, NormalizedRunner
+from src.paddock_parser.base import NormalizedRunner
 
 @pytest.fixture
 def mock_html():

--- a/tests/database/test_manager.py
+++ b/tests/database/test_manager.py
@@ -1,7 +1,5 @@
 import sqlite3
 import pytest
-from dataclasses import dataclass, field
-from typing import List
 
 # Import the data models from their new, dedicated file
 from paddock_parser.models import Race, Runner

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import List, Callable
+from typing import List
 
 # These updated models reflect the changes you will make in src/paddock_parser/models.py
 from paddock_parser.models import Race, Runner

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -1,6 +1,4 @@
 import pytest
-from dataclasses import dataclass, field
-from typing import List
 
 from paddock_parser.models import Race, Runner
 
@@ -10,7 +8,8 @@ try:
     from paddock_parser.merger import smart_merge
 except (ImportError, ModuleNotFoundError):
     # This allows the test file to be parsed even if the merger module doesn't exist yet
-    smart_merge = lambda races: races
+    def smart_merge(races):
+        return races
 
 
 # --- Test Cases for Operation SmartMerge ---

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1,7 +1,7 @@
 import pytest
 from datetime import datetime, timedelta
-from src.paddock_parser.models import Race, Runner # Models are now imported
-from src.paddock_parser.scorer import get_high_roller_races, _convert_odds_to_float
+from src.paddock_parser.models import Race, Runner
+from src.paddock_parser.scorer import get_high_roller_races, _convert_odds_to_float, calculate_weighted_score
 
 # --- Test for the Odds Conversion Utility ---
 @pytest.mark.parametrize("odds_str, expected_float", [
@@ -41,10 +41,6 @@ def test_sorts_races_by_high_roller_score(sample_races):
     assert sorted_races[2].race_id == "RACE_LOW_ODDS_FAV"
 
 
-import pytest
-from src.paddock_parser.models import Race, Runner
-from src.paddock_parser.scorer import calculate_weighted_score # This is the new function you will create
-
 def test_calculate_weighted_score():
     """
     SPEC: The weighted score must correctly apply weights to different race factors.
@@ -64,12 +60,7 @@ def test_calculate_weighted_score():
         "FIELD_SIZE_WEIGHT": 0.6,
         "FAVORITE_ODDS_WEIGHT": 0.4
     }
-    # Arrange: Expected score calculation
-    # This formula is for testing purposes. A lower runner count is better (so we use 1/runners).
-    # Higher favorite odds are better.
-    expected_score = ( (1 / len(race.runners)) * weights["FIELD_SIZE_WEIGHT"] ) + \
-                     ( 2.5 * weights["FAVORITE_ODDS_WEIGHT"] )
-    # expected_score = ( (1/2) * 0.6 ) + ( 2.5 * 0.4 ) = 0.3 + 1.0 = 1.3
+    # Act
 
     # Act
     actual_score = calculate_weighted_score(race, weights)

--- a/tests/ui/test_terminal_ui.py
+++ b/tests/ui/test_terminal_ui.py
@@ -3,13 +3,11 @@ Test-as-Spec for Terminal UI Module
 Path: tests/ui/test_terminal_ui.py
 """
 
-import pytest
-from unittest.mock import Mock, patch, MagicMock, call
+from unittest.mock import Mock, patch, call
 from datetime import datetime
-import logging
 
 # Assume these data structures will be imported from the project
-from paddock_parser.base import NormalizedRace, NormalizedRunner
+from paddock_parser.base import NormalizedRace
 
 
 class TestTerminalUIInitialization:
@@ -96,8 +94,6 @@ class TestLoggingIntegration:
         mock_rich_handler_class.assert_called_once()
         assert terminal_ui.log_handler is not None
 
-
-from unittest.mock import patch
 
 @patch('src.paddock_parser.ui.terminal_ui.Console')
 def test_display_high_roller_report_shows_info_when_empty(MockConsole):

--- a/tests/ui/test_terminal_ui_rich.py
+++ b/tests/ui/test_terminal_ui_rich.py
@@ -1,6 +1,5 @@
 import pytest
-from unittest.mock import MagicMock, patch, call
-import asyncio
+from unittest.mock import patch, call
 from datetime import datetime
 from paddock_parser.models import Race, Runner
 from paddock_parser.base import NormalizedRace, NormalizedRunner


### PR DESCRIPTION
This commit applies linting fixes across the codebase using Ruff.

- Automatically fixed 37 issues, primarily unused imports.
- Manually fixed 6 remaining issues, including misplaced imports and other code style improvements.
- The test suite has been run to confirm that these changes did not introduce any regressions.