### PR TITLE
feat: Implement Tiered Dashboard report

### DIFF
--- a/src/paddock_parser/scorer.py
+++ b/src/paddock_parser/scorer.py
@@ -88,3 +88,38 @@ def calculate_weighted_score(race: Race, weights: dict) -> float:
     # Calculate final score
     score = field_size_component + favorite_odds_component
     return score
+
+
+def score_trifecta_factors(races: List[Race]) -> dict:
+    """
+    Categorizes races into three tiers based on the "Trifecta of Factors."
+    The base factor is always having fewer than 7 runners.
+    """
+    tiered_results = {"tier_1": [], "tier_2": [], "tier_3": []}
+
+    for race in races:
+        # Base criteria: must have fewer than 7 runners to be considered for any tier.
+        if len(race.runners) >= 7:
+            continue
+
+        factors_met = 1  # Start with 1 factor for passing the runner count criteria.
+
+        # Sort runners by odds to find favorite and 2nd favorite
+        runners_with_odds = sorted([r for r in race.runners if r.odds is not None], key=lambda r: r.odds)
+
+        # Factor 2: Favorite's odds > 1.0
+        if len(runners_with_odds) >= 1 and runners_with_odds[0].odds > 1.0:
+            factors_met += 1
+
+        # Factor 3: Second favorite's odds > 4.0
+        if len(runners_with_odds) >= 2 and runners_with_odds[1].odds > 4.0:
+            factors_met += 1
+
+        if factors_met == 3:
+            tiered_results["tier_1"].append(race)
+        elif factors_met == 2:
+            tiered_results["tier_2"].append(race)
+        elif factors_met == 1:
+            tiered_results["tier_3"].append(race)
+
+    return tiered_results

--- a/tests/test_tiered_dashboard.py
+++ b/tests/test_tiered_dashboard.py
@@ -1,0 +1,81 @@
+import pytest
+from unittest.mock import MagicMock, call, patch
+
+from src.paddock_parser.models import Race, Runner
+from src.paddock_parser.scorer import score_trifecta_factors
+from src.paddock_parser.ui.terminal_ui import TerminalUI
+
+# --- Test Data Fixture ---
+@pytest.fixture
+def sample_races_for_tiering():
+    # Adding dummy data for required fields to satisfy the Race model's __init__
+    dummy_time = "00:00"
+    dummy_number = 1
+    dummy_handicap = False
+    return [
+        # TIER 1: The "Perfect Match" (All 3 factors)
+        # 2nd Fav > 4.0, Runners < 7, Fav > 1.0
+        Race(race_id="T1_PERFECT", venue="Tier1", race_time=dummy_time, race_number=dummy_number, is_handicap=dummy_handicap, runners=[
+            Runner(name="Fav", odds=1.5),
+            Runner(name="2ndFav", odds=4.5),
+            Runner(name="Other", odds=10.0)
+        ]),
+        # TIER 2: Two factors (2nd Fav > 4.0, Runners < 7, Fav <= 1.0)
+        Race(race_id="T2_NO_FAV_ODDS", venue="Tier2", race_time=dummy_time, race_number=dummy_number, is_handicap=dummy_handicap, runners=[
+            Runner(name="Fav", odds=0.8),
+            Runner(name="2ndFav", odds=5.0)
+        ]),
+        # TIER 3: One factor (Runners < 7 only)
+        Race(race_id="T3_ONLY_RUNNERS", venue="Tier3", race_time=dummy_time, race_number=dummy_number, is_handicap=dummy_handicap, runners=[
+            Runner(name="Fav", odds=1.0),
+            Runner(name="2ndFav", odds=2.0)
+        ]),
+        # TIER NULL: No factors (Runners > 7)
+        Race(race_id="TNULL_TOO_MANY_RUNNERS", venue="TierNull", race_time=dummy_time, race_number=dummy_number, is_handicap=dummy_handicap, runners=[Runner(name=f"R{i}", odds=float(i+2)) for i in range(8)]),
+    ]
+
+# --- Test for "The Brain" (scorer.py) ---
+def test_score_trifecta_factors_categorizes_correctly(sample_races_for_tiering):
+    """
+    SPEC: The scorer must correctly categorize races into three tiers based on the
+    Project Lead's "Trifecta of Factors."
+    """
+    # Act
+    tiered_results = score_trifecta_factors(sample_races_for_tiering)
+
+    # Assert
+    assert len(tiered_results["tier_1"]) == 1
+    assert tiered_results["tier_1"][0].race_id == "T1_PERFECT"
+
+    assert len(tiered_results["tier_2"]) == 1
+    assert tiered_results["tier_2"][0].race_id == "T2_NO_FAV_ODDS"
+
+    assert len(tiered_results["tier_3"]) == 1
+    assert tiered_results["tier_3"][0].race_id == "T3_ONLY_RUNNERS"
+
+# --- Test for "The Face" (terminal_ui.py) ---
+@patch('src.paddock_parser.ui.terminal_ui.Table')
+@patch('src.paddock_parser.ui.terminal_ui.Console')
+def test_display_tiered_dashboard_creates_multiple_tables(MockConsole, MockTable, sample_races_for_tiering):
+    """
+    SPEC: The UI must create three separate, correctly titled tables when presented
+    with a full set of tiered data.
+    """
+    # Arrange
+    mock_console_instance = MockConsole.return_value
+    tiered_data = score_trifecta_factors(sample_races_for_tiering)
+    ui = TerminalUI(console=mock_console_instance)
+
+    # Act
+    ui.display_tiered_dashboard(tiered_data) # This is the new function you will create
+
+    # Assert
+    # 1. It should have attempted to print three times (once for each table).
+    assert mock_console_instance.print.call_count == 3
+
+    # 2. It should have created three tables with the correct, distinct titles.
+    assert MockTable.call_count == 3
+    call_args_list = [call.kwargs['title'] for call in MockTable.call_args_list]
+    assert "[bold green]== Tier 1: The Perfect Match ==[/bold green]" in call_args_list
+    assert "[bold yellow]== Tier 2: The Strong Contenders ==[/bold yellow]" in call_args_list
+    assert "[bold cyan]== Tier 3: The Singular Signals ==[/bold cyan]" in call_args_list


### PR DESCRIPTION
This commit introduces the 'Tiered Dashboard' feature, a new analytical report that categorizes races based on a 'Trifecta of Factors'.

Key changes:
- Adds a new `score_trifecta_factors` function to `scorer.py` to handle the tiering logic.
- Adds a new `display_tiered_dashboard` function to `terminal_ui.py` to render the results in multiple rich tables.
- Integrates the new report into the main interactive menu, replacing the 'High Roller Report'.
- Includes a new 'Test-as-Spec' file (`tests/test_tiered_dashboard.py`) to verify the new functionality.

This commit also includes the work from two prior missions on this branch: 'Operation Codify the Scalpel' (updating AGENTS.md) and 'Operation Phoenix Rising' (integrating salvaged code for the UI and run logic), per the project's cumulative review workflow.