### PR TITLE
feat: Add Tiered Dashboard and fix pipeline return signature

### DIFF
--- a/src/paddock_parser/pipeline.py
+++ b/src/paddock_parser/pipeline.py
@@ -76,21 +76,25 @@ async def run_pipeline(
     time_window_minutes: int,
     specific_source: str = None,
     ui: Optional['TerminalUI'] = None
-) -> List[NormalizedRace]:
-    """Orchestrates the end-to-end pipeline."""
+) -> Tuple[List[NormalizedRace], int, int]:
+    """
+    Orchestrates the end-to-end pipeline.
+    Returns a tuple of (races, enabled_adapter_count, successful_adapter_count).
+    """
     logging.info("--- Paddock Parser NG Pipeline Start ---")
 
     unmerged_races: List[Race] = []
     prog_num_map: Dict[Tuple[str, str], int] = {}  # Map to preserve program numbers across lossy conversion
     adapter_classes = load_adapters(specific_source)
     races_per_adapter: Dict[str, int] = {}
+    enabled_adapter_count = len(adapter_classes)
 
     if not adapter_classes:
         logging.warning("No adapters found.")
-        return []
+        return [], 0, 0
 
-    if ui:
-        ui.start_fetching_progress(len(adapter_classes))
+    if ui and hasattr(ui, 'start_fetching_progress'):
+        ui.start_fetching_progress(enabled_adapter_count)
 
     for adapter_class in adapter_classes:
         adapter = adapter_class()
@@ -125,11 +129,13 @@ async def run_pipeline(
         except Exception:
             logging.error(f"An error occurred in the '{source_id}' adapter. See details below.", exc_info=True)
         finally:
-            if ui:
+            if ui and hasattr(ui, 'update_fetching_progress'):
                 ui.update_fetching_progress()
 
-    if ui:
+    if ui and hasattr(ui, 'stop_fetching_progress'):
         ui.stop_fetching_progress()
+
+    successful_adapter_count = sum(1 for count in races_per_adapter.values() if count > 0)
 
     logging.info("\n--- Data Ingestion Summary ---")
     for source, count in races_per_adapter.items():
@@ -142,7 +148,7 @@ async def run_pipeline(
 
     if not unmerged_races:
         logging.info("No races were successfully parsed from any source.")
-        return []
+        return [], enabled_adapter_count, successful_adapter_count
 
     # Merge the races
     logging.info(f"Merging {len(unmerged_races)} race records...")
@@ -181,4 +187,4 @@ async def run_pipeline(
     final_normalized_races.sort(key=lambda r: r.score or 0, reverse=True)
 
     logging.info("--- Pipeline End ---")
-    return final_normalized_races
+    return final_normalized_races, enabled_adapter_count, successful_adapter_count

--- a/src/paddock_parser/run.py
+++ b/src/paddock_parser/run.py
@@ -49,7 +49,7 @@ def main():
     ui = TerminalUI()
     ui.setup_logging()
 
-    races, adapter_count = asyncio.run(run_pipeline(
+    races, enabled_adapter_count, successful_adapter_count = asyncio.run(run_pipeline(
         min_runners=args.min_runners,
         time_window_minutes=args.time_window,
         specific_source=args.source,
@@ -59,7 +59,10 @@ def main():
     if races:
         ui.display_races(races)
     else:
-        ui.console.print(f"[yellow]No races were found from {adapter_count} enabled adapters.[/yellow]")
+        ui.console.print(
+            f"[yellow]No races found from {enabled_adapter_count} enabled adapters "
+            f"({successful_adapter_count} successfully returned data).[/yellow]"
+        )
 
 if __name__ == "__main__":
     main()

--- a/tests/ui/test_terminal_ui_rich.py
+++ b/tests/ui/test_terminal_ui_rich.py
@@ -50,7 +50,7 @@ async def test_run_high_roller_report_uses_rich_status(
     mock_console_instance = MockConsole()
     async def mock_pipeline(*args, **kwargs):
         races = [NormalizedRace(race_id="D1", track_name="Dummy", race_number=1, post_time=datetime.now(), runners=[NormalizedRunner(name="DummyHorse", program_number=1, odds=10.0)])]
-        return races, 1
+        return races, 1, 1
     MockRunPipeline.side_effect = mock_pipeline
     MockGetHighRoller.return_value = sample_high_roller_races
     ui = TerminalUI(console=mock_console_instance)
@@ -65,7 +65,10 @@ async def test_run_high_roller_report_uses_rich_status(
 @patch('paddock_parser.ui.terminal_ui.Console')
 async def test_run_high_roller_report_no_races(MockConsole, MockRunPipeline):
     mock_console_instance = MockConsole.return_value
-    MockRunPipeline.return_value = ([], 5)
+    MockRunPipeline.return_value = ([], 5, 0)
     ui = TerminalUI(console=mock_console_instance)
     await ui._run_high_roller_report()
-    mock_console_instance.print.assert_called_once_with("[yellow]No races were found for 5 enabled adapters.[/yellow]")
+    mock_console_instance.print.assert_called_once_with(
+        "[yellow]No races found from 5 enabled adapters "
+        "(0 successfully returned data).[/yellow]"
+    )


### PR DESCRIPTION
This commit introduces the 'Tiered Dashboard' feature and fixes a breaking change in the `run_pipeline` function.

'Tiered Dashboard' feature:
- Adds a `score_trifecta_factors` function to `scorer.py` for tiering logic.
- Adds a `display_tiered_dashboard` function to `terminal_ui.py` to render the results.
- Integrates the new report into the main interactive menu.
- Adds `tests/test_tiered_dashboard.py` to verify the new functionality.

Pipeline fix:
- Modifies `run_pipeline` to return a tuple of `(races, enabled_adapter_count, successful_adapter_count)`.
- Updates calls to `run_pipeline` in `run.py` and `terminal_ui.py` to handle the new signature.
- Fixes a `TypeError` in `terminal_ui.py` by passing the required `time_window_minutes` argument.
- Enhances the "no races found" summary message with more detailed adapter counts.
- Updates mock return values in `tests/ui/test_terminal_ui_rich.py` to align with the new pipeline signature.