### PR TITLE
Feat: Implement Backend Prediction Engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ env/
 # IDE settings
 .vscode/
 .idea/
+
+# Database files
+*.db
+*.sqlite
+*.sqlite3

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,3 +126,27 @@ A curated list of projects and resources to accelerate development.
 8.  **scrapy-horse-racing:** https://github.com/chrismattmann/scrapy-horse-racing
 9.  **horse-racing-data:** https://github.com/jeffkub/horse-racing-data
 10. **Greyhound results scraping example:** https://stackoverflow.com/questions/77761268/...
+
+---
+
+## Part 4: The "Checkmate" Endgame (September 2025)
+
+After achieving a stable V4 architecture and a powerful, multi-source data pipeline, the project has received its final, unifying Prime Directive from its solitary, final customer. The sole and exclusive goal of the "Modern Renaissance" is now to build and verify a single, specific betting angle.
+
+### The Prime Directive: The "Favorite to Place" Angle
+
+The application's purpose is to identify "Checkmate" races that meet a dynamic, odds-based criteria, and then to track the historical profitability of a single, specific bet within those races: the **"Favorite to Place"** bet (a wager that the favorite at post time will finish in either 1st or 2nd place).
+
+All future development will be in service of this single, laser-focused goal.
+
+### The "Closed Loop" Architecture
+
+To achieve this, the project will be evolved into a "Closed Loop" analytical system with three core engines:
+
+1.  **The Prediction Engine:** A live monitor that uses our V3 adapters (`TwinSpires`, `RPB2B`, etc.) to find pre-race "Checkmate" opportunities and logs them to a permanent database.
+
+2.  **The Historian Engine:** A new class of results-focused adapters designed for one purpose: to fetch the official results of a completed race and, crucially, to extract the specific **payout value** for the favorite's "Place" finish.
+
+3.  **The Accountant Engine:** A final, analytical process that joins the predictions with the results to calculate the precise, long-term **Return on Investment (ROI)** of the "Favorite to Place" strategy. The final output will be a cumulative P/L graph, which will serve as the project's ultimate report card.
+
+This "Endgame" phase moves the project beyond simple data acquisition and into the realm of true, verifiable, and continuously improving analytical intelligence.

--- a/checkmate_monitor.html
+++ b/checkmate_monitor.html
@@ -39,7 +39,6 @@ th,td{text-align:left;padding:8px;border-bottom:1px solid var(--border);font-siz
 .ticker{margin:12px 0;padding:8px;border:1px dashed var(--border);border-radius:6px;background:#fcfcff}
 .ticker h4{margin:0 0 8px}
 .initial-state{text-align:center;color:var(--muted);margin:40px 0;padding:20px;border:2px dashed var(--border);border-radius:8px;background:#fafafa}
-#logContainer h3{border-bottom:none;padding-bottom:0;margin-bottom:0}
 @media (max-width:380px){.grid{grid-template-columns:1fr}}
 </style>
 </head>
@@ -75,14 +74,6 @@ th,td{text-align:left;padding:8px;border-bottom:1px solid var(--border);font-siz
   <div class="hint" id="proxyHint">
     If nothing loads, the public CORS proxy may be rate-limited. You might need to request temporary access at cors-anywhere.herokuapp.com/corsdemo, or configure your own proxy endpoint.
   </div>
-
-  <div id="logContainer" class="card" style="display: none; margin-top: 16px;">
-    <div class="row">
-      <h3>Opportunity Log</h3>
-      <button id="clearLogBtn" class="secondary small">Clear Log</button>
-    </div>
-    <div id="logContent"></div>
-  </div>
 </div>
 <script>
 // =============================
@@ -105,9 +96,6 @@ const testModeToggle = document.getElementById('testModeToggle');
 const wsToggle = document.getElementById('wsToggle');
 const liveTicker = document.getElementById('liveTicker');
 const tickerFeed = document.getElementById('tickerFeed');
-const logContainer = document.getElementById('logContainer');
-const logContent = document.getElementById('logContent');
-const clearLogBtn = document.getElementById('clearLogBtn');
 
 // State
 let isMonitoring = false;
@@ -373,10 +361,6 @@ function findCheckmateOpportunities(races){
 // UI
 // =============================
 function displayOpportunities(opps){
-  if (opps.length > 0) {
-    opps.forEach(opp => opportunityLog.add(opp));
-  }
-
   if (!opps.length){ opportunitiesDiv.style.display = 'none'; opportunitiesDiv.innerHTML = ''; return; }
   let html = '<h3>🚨 Checkmate Opportunities</h3>';
   html += '<table><thead><tr><th>Track</th><th>Race</th><th>Fav Odds</th><th>2nd Fav Odds</th><th>Field</th></tr></thead><tbody>';
@@ -429,90 +413,6 @@ function setLoading(loading){
   refreshBtn.disabled = loading || !isMonitoring;
   monitorBtn.disabled = loading && isMonitoring;
 }
-
-// =============================
-// Opportunity Log
-// =============================
-const opportunityLog = {
-    STORAGE_KEY: 'checkmate_opportunity_log',
-    _log: [],
-
-    init() {
-        this.load();
-        this.render();
-        clearLogBtn.addEventListener('click', () => this.clear());
-    },
-
-    load() {
-        try {
-            const storedLog = localStorage.getItem(this.STORAGE_KEY);
-            this._log = storedLog ? JSON.parse(storedLog) : [];
-        } catch (e) {
-            console.error("Failed to load opportunity log from localStorage", e);
-            this._log = [];
-        }
-    },
-
-    save() {
-        try {
-            localStorage.setItem(this.STORAGE_KEY, JSON.stringify(this._log));
-        } catch (e) {
-            console.error("Failed to save opportunity log to localStorage", e);
-        }
-    },
-
-    add(opportunity) {
-        const sortedRunners = [...opportunity.runners].sort((a, b) => a.odds - b.odds);
-        const opportunityId = `${keyOf(opportunity)}-${sortedRunners[0].odds}-${sortedRunners[1].odds}`;
-
-        if (!this._log.some(item => item.id === opportunityId)) {
-            const logEntry = {
-                id: opportunityId,
-                track: opportunity.track,
-                raceNumber: opportunity.raceNumber,
-                timestamp: new Date().toISOString(),
-                favOdds: sortedRunners[0].odds,
-                secondFavOdds: sortedRunners[1].odds,
-                fieldSize: opportunity.runners.length
-            };
-            this._log.unshift(logEntry);
-            this.save();
-            this.render();
-        }
-    },
-
-    clear() {
-        if (confirm("Are you sure you want to clear the entire opportunity log?")) {
-            this._log = [];
-            this.save();
-            this.render();
-        }
-    },
-
-    render() {
-        if (this._log.length === 0) {
-            logContainer.style.display = 'none';
-            return;
-        }
-        logContainer.style.display = 'block';
-
-        let html = '<table><thead><tr><th>Logged</th><th>Track</th><th>Race</th><th>Fav Odds</th><th>2nd Fav Odds</th><th>Field</th></tr></thead><tbody>';
-        this._log.forEach(entry => {
-            html += `
-                <tr>
-                    <td class="small muted">${new Date(entry.timestamp).toLocaleString()}</td>
-                    <td>${escapeHtml(entry.track)}</td>
-                    <td>${entry.raceNumber}</td>
-                    <td class="mono">${fmtOdds(entry.favOdds)}</td>
-                    <td class="mono">${fmtOdds(entry.secondFavOdds)}</td>
-                    <td>${entry.fieldSize}</td>
-                </tr>
-            `;
-        });
-        html += '</tbody></table>';
-        logContent.innerHTML = html;
-    }
-};
 
 // =============================
 // Test Data
@@ -615,8 +515,6 @@ document.addEventListener('DOMContentLoaded', () => {
       <h3>Welcome to Checkmate Monitor</h3>
       <p>Start monitoring to see live racing data and checkmate opportunities.</p>
     </div>`;
-
-  opportunityLog.init();
 });
 
 // =============================
@@ -637,4 +535,3 @@ wsToggle.addEventListener('change', () => {
 </script>
 </body>
 </html>
- 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 [project.scripts]
 paddock_parser_ui = "paddock_parser.entry_points:run_terminal_ui"
 paddock_parser_dashboard = "paddock_parser.entry_points:run_dashboard"
+paddock_parser_predict = "paddock_parser.entry_points:run_prediction_engine"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Core application dependencies
+anyio
 fastapi
 uvicorn[standard]
 pydantic

--- a/src/paddock_parser/database/manager.py
+++ b/src/paddock_parser/database/manager.py
@@ -1,7 +1,7 @@
 import sqlite3
 from typing import List
 from collections import defaultdict
-from src.paddock_parser.models import Race, Runner
+from paddock_parser.models import Race, Runner, Prediction
 
 class DatabaseManager:
     def __init__(self, db_path: str):
@@ -34,7 +34,42 @@ class DatabaseManager:
                 FOREIGN KEY (race_id) REFERENCES races (race_id) ON DELETE CASCADE
             )
         """)
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS predictions (
+                prediction_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                race_id TEXT NOT NULL,
+                track TEXT NOT NULL,
+                race_number INTEGER NOT NULL,
+                predicted_at TEXT NOT NULL,
+                favorite_name TEXT NOT NULL,
+                favorite_odds REAL NOT NULL,
+                UNIQUE(race_id, predicted_at)
+            )
+        """)
         self.conn.commit()
+
+    def save_prediction(self, prediction: Prediction):
+        """Saves a prediction to the database."""
+        cursor = self.conn.cursor()
+        try:
+            cursor.execute("""
+                INSERT INTO predictions (race_id, track, race_number, predicted_at, favorite_name, favorite_odds)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """, (
+                prediction.race_id,
+                prediction.track,
+                prediction.race_number,
+                prediction.predicted_at.isoformat(),
+                prediction.favorite_name,
+                prediction.favorite_odds
+            ))
+            self.conn.commit()
+        except sqlite3.IntegrityError:
+            # This is expected if we try to log the same opportunity again, so we can ignore it silently.
+            self.conn.rollback()
+        except sqlite3.Error as e:
+            print(f"Database error during prediction save: {e}")
+            self.conn.rollback()
 
     def save_race(self, race: Race):
         """Saves a race and its runners to the database using an upsert logic."""

--- a/src/paddock_parser/entry_points.py
+++ b/src/paddock_parser/entry_points.py
@@ -19,12 +19,26 @@ def run_dashboard():
     dashboard_path = Path(__file__).resolve().parents[2] / "launch_dashboard.py"
     subprocess.run(["streamlit", "run", str(dashboard_path)])
 
+def run_prediction_engine():
+    """Entry point for the Prediction Engine."""
+    # This path hack is needed to ensure relative imports in the engine work
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import anyio
+    from paddock_parser.prediction_engine import main as run_engine_main
+
+    anyio.run(run_engine_main)
+
 if __name__ == '__main__':
     # This allows running the entry points directly for testing
     # e.g., python -m src.paddock_parser.entry_points ui
-    if len(sys.argv) > 1 and sys.argv[1] == 'ui':
-        run_terminal_ui()
-    elif len(sys.argv) > 1 and sys.argv[1] == 'dashboard':
-        run_dashboard()
+    if len(sys.argv) > 1:
+        if sys.argv[1] == 'ui':
+            run_terminal_ui()
+        elif sys.argv[1] == 'dashboard':
+            run_dashboard()
+        elif sys.argv[1] == 'predict':
+            run_prediction_engine()
+        else:
+            print("Usage: python -m src.paddock_parser.entry_points [ui|dashboard|predict]")
     else:
-        print("Usage: python -m src.paddock_parser.entry_points [ui|dashboard]")
+        print("Usage: python -m src.paddock_parser.entry_points [ui|dashboard|predict]")

--- a/src/paddock_parser/models.py
+++ b/src/paddock_parser/models.py
@@ -36,3 +36,13 @@ class NormalizedRace:
     race_number: int
     race_time: datetime
     runners: List[NormalizedRunner] = field(default_factory=list)
+    source: Optional[str] = None
+
+@dataclass
+class Prediction:
+    race_id: str
+    track: str
+    race_number: int
+    predicted_at: datetime
+    favorite_name: str
+    favorite_odds: float

--- a/src/paddock_parser/prediction_engine.py
+++ b/src/paddock_parser/prediction_engine.py
@@ -1,0 +1,135 @@
+import anyio
+import logging
+from datetime import datetime
+from typing import List, Dict, Optional
+
+from .adapters.twinspires_adapter import TwinSpiresAdapter
+from .adapters.racingpost_adapter import RacingPostAdapter
+from .adapters.pointsbet_adapter import PointsBetAdapter
+from .database.manager import DatabaseManager
+from .models import NormalizedRace, Prediction
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def get_dynamic_odds_thresholds(field_size: int) -> Dict[str, float]:
+    """Ported from the Checkmate Monitor JavaScript, this determines the odds
+    thresholds for identifying an opportunity based on field size."""
+    if field_size <= 4: return {"fav": 0.5, "secondFav": 2.0}
+    if field_size == 5: return {"fav": 0.8, "secondFav": 3.0}
+    if field_size == 6: return {"fav": 1.0, "secondFav": 3.5}
+    return {"fav": 1.0, "secondFav": 4.0}
+
+def find_checkmate_opportunities(races: List[NormalizedRace]) -> List[NormalizedRace]:
+    """Ported from the Checkmate Monitor JavaScript, this filters a list of races
+    to find 'Checkmate' opportunities based on the odds of the top two favorites."""
+    opportunities = []
+    for race in races:
+        # The JS logic only applies to Thoroughbreds. The adapters should ideally provide this,
+        # but for now, we assume they are returning relevant race types.
+        if not race.runners or not (2 <= len(race.runners) < 7):
+            continue
+
+        # Ensure all runners have odds before sorting
+        valid_runners = [r for r in race.runners if r.odds is not None]
+        if len(valid_runners) < 2:
+            continue
+
+        sorted_runners = sorted(valid_runners, key=lambda r: r.odds)
+        thresholds = get_dynamic_odds_thresholds(len(sorted_runners))
+
+        fav = sorted_runners[0]
+        second = sorted_runners[1]
+
+        if fav.odds > thresholds["fav"] and second.odds > thresholds["secondFav"]:
+            opportunities.append(race)
+    return opportunities
+
+class PredictionEngine:
+    """
+    The first engine in the "Closed Loop" architecture. It finds pre-race
+    "Checkmate" opportunities and logs them to a permanent database.
+    """
+    def __init__(self, db_path: str = "paddock_parser.db"):
+        self.db_manager = DatabaseManager(db_path)
+        # Ensure tables exist before running
+        self.db_manager.create_tables()
+        self.adapters = {
+            "TwinSpires": TwinSpiresAdapter(),
+            "PointsBet": PointsBetAdapter()
+            # RacingPost is an offline adapter and cannot be used in the live waterfall.
+        }
+
+    async def run_waterfall(self) -> List[NormalizedRace]:
+        """
+        Attempts to fetch race data from a series of adapters in a waterfall sequence.
+        It stops and returns the data from the first successful adapter.
+        """
+        logging.info("Starting data acquisition waterfall...")
+        # Order matches the "Gold -> Silver -> Contender" logic from the monitor
+        waterfall_order = ["TwinSpires", "PointsBet"]
+
+        for adapter_name in waterfall_order:
+            adapter = self.adapters.get(adapter_name)
+            if not adapter:
+                continue
+
+            logging.info(f"Attempting to fetch data from {adapter_name}...")
+            try:
+                races = await adapter.fetch()
+                if races:
+                    logging.info(f"Successfully fetched {len(races)} races from {adapter_name}.")
+                    # Add source information to each race
+                    for race in races:
+                        race.source = adapter_name
+                    return races
+            except Exception as e:
+                logging.error(f"Failed to fetch data from {adapter_name}: {e}", exc_info=True)
+
+        logging.warning("Waterfall complete. No data was fetched from any source.")
+        return []
+
+    def process_and_log_opportunities(self, opportunities: List[NormalizedRace]):
+        """
+        Processes a list of opportunity races and saves them as Prediction records
+        in the database.
+        """
+        if not opportunities:
+            logging.info("No new checkmate opportunities found.")
+            return
+
+        logging.info(f"Found {len(opportunities)} new checkmate opportunities. Logging to database...")
+        for opp in opportunities:
+            sorted_runners = sorted([r for r in opp.runners if r.odds is not None], key=lambda r: r.odds)
+            fav = sorted_runners[0]
+
+            # Create a more robust race_id for the database
+            race_id = f"{opp.source}-{opp.track}-{opp.race_time.strftime('%Y%m%d')}-R{opp.race_number}"
+
+            prediction = Prediction(
+                race_id=race_id,
+                track=opp.track,
+                race_number=opp.race_number,
+                predicted_at=datetime.now(),
+                favorite_name=fav.name,
+                favorite_odds=fav.odds,
+            )
+            self.db_manager.save_prediction(prediction)
+
+        logging.info(f"Successfully logged {len(opportunities)} predictions.")
+
+    async def run(self):
+        """Main execution method for the engine."""
+        logging.info("Prediction Engine run started.")
+        races = await self.run_waterfall()
+        opportunities = find_checkmate_opportunities(races)
+        self.process_and_log_opportunities(opportunities)
+        self.db_manager.close()
+        logging.info("Prediction Engine run finished.")
+
+async def main():
+    """Asynchronous entry point for the script."""
+    engine = PredictionEngine()
+    await engine.run()
+
+if __name__ == "__main__":
+    anyio.run(main)

--- a/src/paddock_parser_ng.egg-info/SOURCES.txt
+++ b/src/paddock_parser_ng.egg-info/SOURCES.txt
@@ -13,6 +13,7 @@ src/paddock_parser/log_analyzer.py
 src/paddock_parser/merger.py
 src/paddock_parser/models.py
 src/paddock_parser/pipeline.py
+src/paddock_parser/prediction_engine.py
 src/paddock_parser/run.py
 src/paddock_parser/scorer.py
 src/paddock_parser/sync_fetcher.py


### PR DESCRIPTION
This commit introduces the first component of the "Checkmate Endgame" architecture: a Python-based Prediction Engine.

Key features:
- Creates `prediction_engine.py`, a new script that runs a waterfall of data adapters (TwinSpires, PointsBet) to find "Checkmate" opportunities.
- Ports the opportunity-finding logic from JavaScript to Python.
- Adds a new `predictions` table to the SQLite database schema to permanently log found opportunities.
- Creates a `paddock_parser_predict` command line entry point to run the engine.
- Updates `ROADMAP.md` to reflect the new "Prime Directive".
- Removes the conflicting `localStorage` logging feature from the `checkmate_monitor.html` file to consolidate the architecture.