### PR TITLE
Fix: Correct raw file links in manifest files

### DIFF
--- a/MANIFEST2.md
+++ b/MANIFEST2.md
@@ -1,6 +1,6 @@
 # Checkmate Ultimate Solo: CORE Manifest & Links
 
-**Purpose:** To provide a visual org chart and a complete, actionable list of raw file links for the active **CORE Ultimate Solo** architecture ONLY.
+Purpose: To provide a visual org chart and a complete, actionable list of raw file links for the active CORE Ultimate Solo architecture ONLY.
 
 ---
 
@@ -16,8 +16,15 @@
 ├── python_service/
 │   ├── api.py
 │   ├── engine.py
+│   ├── models.py
 │   ├── requirements.txt
 │   └── adapters/
+│       ├── __init__.py
+│       ├── base.py
+│       ├── betfair_adapter.py
+│       ├── pointsbet_adapter.py
+│       ├── racing_and_sports_adapter.py
+│       └── tvg_adapter.py
 └── web_platform/
     └── frontend/
         └── src/
@@ -30,22 +37,23 @@
 ## CORE File Links
 
 ### Root
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/.env
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/ARCHITECTURAL_MANDATE.md
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/README.md
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/STATUS.md
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/setup_windows.bat
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/.env
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/ARCHITECTURAL_MANDATE.md
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/README.md
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/STATUS.md
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/setup_windows.bat
 
-### Python Backend (`python_service`)
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/python_service/api.py
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/python_service/engine.py
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/python_service/requirements.txt
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/python_service/adapters/__init__.py
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/python_service/adapters/base.py
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/python_service/adapters/betfair_adapter.py
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/python_service/adapters/pointsbet_adapter.py
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/python_service/adapters/tvg_adapter.py
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/python_service/adapters/utils.py
+### Python Backend (python_service)
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/python_service/api.py
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/python_service/engine.py
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/python_service/models.py
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/python_service/requirements.txt
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/python_service/adapters/__init__.py
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/python_service/adapters/base.py
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/python_service/adapters/betfair_adapter.py
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/python_service/adapters/pointsbet_adapter.py
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/python_service/adapters/racing_and_sports_adapter.py
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/python_service/adapters/tvg_adapter.py
 
-### TypeScript Frontend (`web_platform/frontend`)
-https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/main/web_platform/frontend/src/app/page.tsx
+### TypeScript Frontend (web_platform/frontend)
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/web_platform/frontend/src/app/page.tsx

--- a/MANIFEST3.md
+++ b/MANIFEST3.md
@@ -1,0 +1,77 @@
+# Checkmate Ultimate Solo: Operational & Tooling Manifest
+
+**Purpose:** To provide a complete, actionable list of all satellite files that are critical to the project's operation, deployment, and strategic direction. This manifest is intended for architectural review of the project's non-application-code assets.
+
+---
+
+## 1.0 Build & Deployment Tooling
+
+*These files are responsible for compiling and packaging the final `Checkmate.exe` deliverable.*
+
+*   **Build Orchestrator:** `build_ultimate_exe.bat`
+*   **Electron Main Process:** `electron/main.js`
+*   **Electron Configuration:** `electron/package.json`
+
+---
+
+## 2.0 Environment & Setup
+
+*These files configure the developer environment and project dependencies.*
+
+*   **Windows Setup Script:** `setup_windows.bat`
+*   **Environment Variables:** `.env`
+*   **Python Dependencies:** `python_service/requirements.txt`
+
+---
+
+## 3.0 Strategic Blueprints & Sacred Texts
+
+*These documents define the project's history, architecture, status, and future campaigns. They are the single source of truth for the project's intent.*
+
+*   **README:** `README.md`
+*   **Architectural Mandate:** `ARCHITECTURAL_MANDATE.md`
+*   **Project History:** `HISTORY.md`
+*   **Final Campaigns:** `FINAL_CAMPAIGNS.md`
+*   **Project Status:** `STATUS.md`
+*   **Jules1002 Protocol:** `WISDOM.md`
+*   **Legacy Manifest:** `PROJECT_MANIFEST.md`
+
+---
+
+## 4.0 Intelligence Briefings (Council of Superbrains)
+
+*These files contain the external analysis that guides our strategic pivots and validation.*
+
+*   **Primary Intelligence:** `checkmate_review.md`
+*   **Archived Intelligence (Claude):** `attic/claude_review_team_effort.md.txt`
+*   **Archived Intelligence (GPT-4o):** `attic/gpt4o_review.md.txt`
+*   **Archived Intelligence (Grok):** `attic/grok_review.md.txt`
+
+---
+
+## 5.0 Raw File Links for Review
+
+### Build & Deployment
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/build_ultimate_exe.bat
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/electron/main.js
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/electron/package.json
+
+### Environment & Setup
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/setup_windows.bat
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/.env
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/python_service/requirements.txt
+
+### Strategic Blueprints
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/README.md
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/ARCHITECTURAL_MANDATE.md
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/HISTORY.md
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/FINAL_CAMPAIGNS.md
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/STATUS.md
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/WISDOM.md
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/PROJECT_MANIFEST.md
+
+### Intelligence Briefings
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/checkmate_review.md
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/attic/claude_review_team_effort.md.txt
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/attic/gpt4o_review.md.txt
+https://raw.githubusercontent.com/masonj0/scrape-sort_races-toteboards/refs/heads/main/attic/grok_review.md.txt


### PR DESCRIPTION
This change corrects critical URL formatting errors in the project's manifest files.

- Overwrites MANIFEST2.md to fix broken raw file URLs.
- Creates MANIFEST3.md with a new set of corrected links.

The previous links were missing the required `refs/heads/` path segment, causing them to return 404 errors. This commit ensures all raw file URLs are fully-qualified and accessible to external review tools.