### PR TITLE
feat: Create HarnessAdapter stub

### DIFF
--- a/python_service/adapters/harness_adapter.py
+++ b/python_service/adapters/harness_adapter.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+import httpx
+from pydantic import ValidationError
+
+import structlog
+
+from python_service.models import Race, Runner
+
+from .base import BaseAdapter
+
+log = structlog.get_logger(__name__)
+
+
+class HarnessAdapter(BaseAdapter):
+    """Adapter for Harness racing data - TEMPLATE.
+
+    This is a foundational template cloned from RacingAndSportsAdapter.
+    The fetch_races and parsing logic will be implemented in a future mission.
+    """
+
+    def __init__(self, http_client: httpx.AsyncClient):
+        super().__init__("https://api.harnessracing.example.com", http_client)
+
+    async def fetch_races(self) -> List[Race]:
+        """Fetches upcoming harness races."""
+        # This is a stub and will be implemented in the next mission.
+        log.warning("HarnessAdapter.fetch_races is not implemented")
+        return []
+
+    def _parse_races(self, races_json: List[Dict[str, Any]]) -> List[Race]:
+        """Parses a list of race dictionaries into Race objects."""
+        # This is a stub and will be implemented in the next mission.
+        return []


### PR DESCRIPTION
This commit introduces the foundational file for the Harness racing data initiative.

Creates the `python_service/adapters/harness_adapter.py` file with the specified template content. This file serves as a placeholder for future implementation of Harness-specific data fetching and parsing logic, establishing the necessary boilerplate within the existing engine architecture.

This work is the first deliverable for 'Operation: Full Spectrum'.